### PR TITLE
Monitor when Arduino is plugged/unplugged 

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -5,7 +5,6 @@ mute and unmute Zoom by pushing a physical button.
 
 ## How to use it
 
-
 ### Set up the hardware
 
 Build the circuit and connect it via USB to your computer.
@@ -35,6 +34,11 @@ the right LED on.
 You can use the buttons on the board or the built-in Zoom controls to mute and unmute yourself and the LEDs will
 adjust accordingly.
 
+### Plug/Unplug the Arduino
+
+If you leave Zoomino run in the background, it should detect when the Arduino is connected and disconnected and behave
+accordingly, setting up and disposing the serial connection and protocol.
+
 #### Allow the terminal to control your computer
 
 Zoomino uses AppleScript to access the Zoom controls and periodically check whether it's muted or unmuted.
@@ -44,5 +48,4 @@ You can check exactly what Zoomino does with AppleScript [here](./lib/zoom.js) (
 
 ## Known issues
 
-* The Arduino needs to be connected before running Zoomino.
 * Zoomino needs to be run manually from the terminal. If you want to run it as a service, you will have to configure it yourself.

--- a/macos/lib/arduino-monitor.js
+++ b/macos/lib/arduino-monitor.js
@@ -1,0 +1,51 @@
+import SerialPort from 'serialport';
+import EventEmitter from 'events';
+import { noopLogger } from './noop-logger.js';
+
+async function getSerialPortForArduino () {
+  const ports = await SerialPort.list();
+  return ports.find(p => /arduino/ig.test(p.manufacturer))?.path;
+}
+
+class ArduinoMonitor extends EventEmitter {
+  constructor () {
+    super();
+    this.logger = noopLogger;
+    this.timer = null;
+    this.connected = null;
+  }
+
+  setLogger (logger) {
+    this.logger = logger;
+  }
+
+  async start () {
+    const port = await getSerialPortForArduino();
+    this.connected = !!port;
+    if (this.connected) {
+      this.emit('arduino-connected', port);
+    }
+    this.timer = setTimeout(this._monitorConnection.bind(this), 1000);
+  }
+
+  stop () {
+    clearTimeout(this.timer);
+  }
+
+  async _monitorConnection () {
+    const port = await getSerialPortForArduino();
+    if (port && !this.connected) {
+      this.logger.debug('arduino connected');
+      this.connected = true;
+      this.emit('arduino-connected', port);
+    }
+    if (!port && this.connected) {
+      this.logger.debug('arduino disconnected');
+      this.connected = false;
+      this.emit('arduino-disconnected');
+    }
+    this.timer = setTimeout(this._monitorConnection.bind(this), 1000);
+  }
+}
+
+export { ArduinoMonitor };

--- a/macos/lib/arduino-monitor.js
+++ b/macos/lib/arduino-monitor.js
@@ -35,7 +35,7 @@ class ArduinoMonitor extends EventEmitter {
   async _monitorConnection () {
     const port = await getSerialPortForArduino();
     if (port && !this.connected) {
-      this.logger.debug('arduino connected');
+      this.logger.debug('arduino connected on port %s', port);
       this.connected = true;
       this.emit('arduino-connected', port);
     }

--- a/macos/lib/noop-logger.js
+++ b/macos/lib/noop-logger.js
@@ -1,0 +1,4 @@
+const noop = () => {};
+const noopLogger = { info: noop, error: noop, debug: noop };
+
+export { noopLogger };

--- a/macos/lib/serial-comm-manager.js
+++ b/macos/lib/serial-comm-manager.js
@@ -46,6 +46,10 @@ class SerialCommunicationManager extends EventEmitter {
   async stop () {
     try {
       this.logger.debug('stopping serial connection');
+      // Soft dispose
+      // Relies on internals :(
+      this.arduino.oneByteParser.removeAllListeners();
+      this.arduino._isInitialized = false;
     } catch (err) {
       this.logger.error(err);
     }

--- a/macos/lib/serial-comm-manager.js
+++ b/macos/lib/serial-comm-manager.js
@@ -3,13 +3,8 @@ import {
   WriteCommandConfig,
   ReadCommandConfig
 } from '@yesbotics/simple-serial-protocol-node';
-import SerialPort from 'serialport';
+import { noopLogger } from './noop-logger.js';
 import EventEmitter from 'events';
-
-async function getSerialPortForArduino () {
-  const ports = await SerialPort.list();
-  return ports.find(p => /arduino/ig.test(p.manufacturer))?.path;
-}
 
 class SerialCommunicationManager extends EventEmitter {
   constructor (path, baudRate = 9600) {
@@ -17,15 +12,7 @@ class SerialCommunicationManager extends EventEmitter {
     this.path = path;
     this.baudRate = baudRate;
     this.arduino = undefined;
-    const noop = () => {};
-    this.logger = { info: noop, error: noop, debug: noop };
-  }
-
-  setLogger (logger) {
-    this.logger = logger;
-  }
-
-  async start () {
+    this.logger = noopLogger;
     this.arduino = new SimpleSerialProtocol(this.path, this.baudRate);
     const readConfig = new ReadCommandConfig('s', (/* byte */ msgType, /* byte */ msgContent) => {
       this.logger.debug('Received message from arduino');
@@ -34,6 +21,13 @@ class SerialCommunicationManager extends EventEmitter {
     });
     readConfig.addByteParam().addByteParam();
     this.arduino.registerCommand(readConfig);
+  }
+
+  setLogger (logger) {
+    this.logger = logger;
+  }
+
+  async start () {
     try {
       await this.arduino.init(2000);
       this.logger.info('connected');
@@ -51,11 +45,11 @@ class SerialCommunicationManager extends EventEmitter {
 
   async stop () {
     try {
-      await this.arduino.dispose();
+      this.logger.debug('stopping serial connection');
     } catch (err) {
       this.logger.error(err);
     }
   }
 }
 
-export { SerialCommunicationManager, getSerialPortForArduino };
+export { SerialCommunicationManager };

--- a/macos/zoomino.js
+++ b/macos/zoomino.js
@@ -22,6 +22,7 @@ async function start () {
     if (msgType !== SerialProtocol.CMD_MSG) {
       return null;
     }
+    logger.debug('received command %d', msgContent);
     switch (msgContent) {
       case SerialProtocol.CmdValue.MUTE:
         logger.info('received mute command');
@@ -46,8 +47,8 @@ async function start () {
     if (!scm) {
       scm = new SerialCommunicationManager(port);
       scm.setLogger(scmLogger);
-      scm.on('message', onMessage);
     }
+    scm.on('message', onMessage);
     await scm.start();
   };
 

--- a/macos/zoomino.js
+++ b/macos/zoomino.js
@@ -45,6 +45,8 @@ async function start () {
 
   const onConnected = async (port) => {
     if (!scm) {
+      // `port` is only used to set up the instance the firs time
+      // An improvement would be to support potential port changes
       scm = new SerialCommunicationManager(port);
       scm.setLogger(scmLogger);
     }


### PR DESCRIPTION
As the `SerialCommunicationManager` instance is only created once, this, for now, relies on the serial port always being the same.